### PR TITLE
[BKY-6457] Use public bky-as of beta 4

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,34 +8,20 @@ let
     overlays = [ ];
   };
 
-  bky-as = pkgs.buildGoModule rec {
+  bky-as = pkgs.stdenv.mkDerivation rec {
     pname = "bky-as";
     version = "v0.1.0-beta.4";
 
-    tmpDir = "/tmp";
-
-    env = {
-      GOPRIVATE = "github.com/blocky/*";
-      HOME = tmpDir;
+    src = pkgs.fetchurl {
+      url = "https://github.com/blocky/attestation-service-demo/releases/download/v0.1.0-beta.4/bky-as_linux_amd64";
+      sha256 = "sha256-Gm/zEiP1jJaloxN6TdiCq112zk6hHlTWu65VkUlNceU=";
     };
 
-    src = builtins.fetchGit {
-      ref = version;
-      url = "git@github.com:blocky/delphi.git";
-    };
+    unpackPhase = ":";
 
-    doCheck = false;
-
-    preBuild = ''
-      echo machine github.com login doesNotMatter password ${githubPAT} > ${tmpDir}/.netrc
+    installPhase = ''
+      install -D -m 555 $src $out/bin/bky-as
     '';
-
-    postInstall = ''
-      cp $out/bin/cli $out/bin/bky-as
-    '';
-
-    vendorHash = "sha256-GXlZz3L5vd1v9NHlaagKw6aY3LEyt9E10reh6EvZ4Bw=";
-
   };
 in
 pkgs.mkShellNoCC {


### PR DESCRIPTION
## Describe your changes

In this PR, we pull the public beta release from 
the version hosted on github, this allows us
to run tests using the same version that our users 
have access to.

## Related Jira cards

[bky-6457](https://blocky.atlassian.net/browse/BKY-6457)

## Notes for reviewers

This version only works with linux (as it hard codes the url).

I was running into some dns issues when using the install script and so 
for now, since I am trying to get this off the ground, I figured 
I would come back to it if we like this idea.

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] I have run `make pre-pr` and all checks have passed.
- [x] This PR is small. 
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
