### PR TITLE
[BKY-6544] Allow specifying commit of unstable version

### DIFF
--- a/nix/fetch-bky-as.sh
+++ b/nix/fetch-bky-as.sh
@@ -2,9 +2,10 @@
 
 set -e
 
-bin=$1
-os=$2
-arch=$3
+commit=$1
+bin=$2
+os=$3
+arch=$4
 
 mkdir -p $bin
 
@@ -17,13 +18,15 @@ else
     echo "no current version"
 fi
 
-echo -n "Getting the latest commit..."
-latest_commit=$(gh api repos/blocky/delphi/commits --jq '.[0].sha')
-echo "'$latest_commit'"
+if [[ $commit == "latest" ]]; then
+  echo -n "Getting the latest commit..."
+  commit=$(gh api repos/blocky/delphi/commits --jq '.[0].sha')
+  echo "'$commit'"
+fi
 
-if [[ $current_version_commit != $latest_commit ]]; then
+if [[ $current_version_commit != "$commit" ]]; then
     echo "Versions differ ...updating"
-    aws s3 cp s3://blocky-internal-release/delphi/cli/$latest_commit/${os}_${arch} ${bin}/bky-as
+    aws s3 cp "s3://blocky-internal-release/delphi/cli/${commit}/${os}_${arch}" "${bin}/bky-as"
     chmod +x "$bin/bky-as"
 else
     echo "Version up to date"

--- a/nix/system.nix
+++ b/nix/system.nix
@@ -1,8 +1,8 @@
 { pkgs }:
 let
-  system = builtins.split "-" pkgs.stdenv.hostPlatform.system;
+  system = pkgs.lib.strings.splitString "-" pkgs.stdenv.hostPlatform.system;
   arch = builtins.elemAt (system) 0;
-  os = builtins.elemAt (system) 2;
+  os = builtins.elemAt (system) 1;
 in
 {
   goos = os;

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,6 @@
+{
+  version ? "latest",
+}:
 let
   nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.11";
   pkgs = import nixpkgs {
@@ -14,7 +17,7 @@ mkDevShell {
   # development shell. On release branches, such as "release/v0.1.0-beta.4"
   # this value should be "v0.1.0-beta.4".  On main, it should be set to
   # "unstable"
-  version = "unstable";
+  version = version;
 
   devDependencies = [
     pkgs.git # for project management

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,10 @@
 {
+  # Specify version from the command line by using a valid semver tag to grab a stable version, e.g.
+  #   `nix-shell --argstr version "v0.1.0-beta.5"`
+  # or a full git commit sha to grab an unstable version, e.g.
+  #   `nix-shell --argstr version "<full git commit sha>"`
+  # or use the default value of "latest" to get the latest unstable version, e.g.
+  #   `nix-shell`
   version ? "latest",
 }:
 let


### PR DESCRIPTION
## Describe your changes
While looking at the basm SDK and how we can manage the environment there using nix, the ability to specify a particular commit came up (for example, as we progress the SDK we may want to pin the tests against a specific commit of delphi, rather than just an official release or latest)

This PR suggests these changes here as a look into increasing the flexibility of the env management in the examples repo. 

## Related Jira cards
loosely: 
https://blocky.atlassian.net/browse/BKY-6544

## Notes for reviewers
We will have to update a few process notes. For example, previously when creating a release branch we would update "unstable" to the specific tag, where now we update "latest" to the specific tag. Nothing too crazy though. 

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [ ] I have run `make pre-pr` and all checks have passed.
    - We don't have a make pre-pr in this repo
- [x] I am merging into the intended base branch.
    - Pretty sure
- [x] This PR is small. 
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
