### PR TITLE
[BKY-6541] Adding PTP information

### DIFF
--- a/time/README.md
+++ b/time/README.md
@@ -50,14 +50,15 @@ Output:
 
 ### Step 1: Create a function for getting the current time
 
-Normally, the Blocky AS runtime does not provide sandboxed functions access to
-the system clock. Instead, they are given a hardcoded time that monotonically 
-increases by "1ns" for every subsequent call.
+Before version 0.1.0.beta-9, the Blocky AS runtime does not provide sandboxed
+functions access to the system clock. Instead, they are given a hardcoded
+time that monotonically increases by "1ns" for every subsequent call.
 
 Starting with 0.1.0-beta.9, guest functions have access
 to time from [`PTP`](https://en.wikipedia.org/wiki/Precision_Time_Protocol).
-Each time a standard library function, like `time.Now()` is invoked the system
-call results in Blocky AS runtime fetching time from `/dev/ptp0` device.
+Each time a guest function calls a standard library time function,
+like `time.Now()`,  the resulting time system call triggers
+the Blocky AS runtime to fetch current time from the `/dev/ptp0` device.
 Read more about this design in the
 [article](https://evervault.com/blog/how-we-built-enclaves-resolving-clock-drift-in-nitro-enclaves).
 


### PR DESCRIPTION
## Describe your changes
Adding information about sourcing time directly from PTP.

## Related Jira cards
[BKY-6541](https://blocky.atlassian.net/browse/BKY-6541)

## Notes for reviewers
I omitted the information about syncing the Enclave's walltime with PTP
as it has no implication on the guest code running in the sandboxed wasm env.
For our customers each time they request time, they're getting a fresh reading
directly from the hypervisor.

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] I have run `make pre-pr` and all checks have passed.
- [x] I am merging into the intended base branch.
- [x] This PR is small. 
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
