### PR TITLE
[BKY-6521] Attestation-service repo name change

### DIFF
--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -14,7 +14,7 @@ let
     pname = "bky-as";
     version = version;
     src = builtins.fetchurl {
-      url = "https://github.com/blocky/attestation-service-demo/releases/download/${version}/bky-as_${goos}_${goarch}";
+      url = "https://github.com/blocky/attestation-service-cli/releases/download/${version}/bky-as_${goos}_${goarch}";
     };
     unpackPhase = ":";
     installPhase = ''


### PR DESCRIPTION
## Describe your changes
This PR updates the URL for fetching release binaries as the repository name has changed from attestation-service-demo to attestation-service-cli. This change only affects those using nix to manage the dev environment in this repo. 

## Related Jira cards
https://blocky.atlassian.net/browse/BKY-6521

## Notes for reviewers
none

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [ ] I have run `make pre-pr` and all checks have passed.
    - There is no `pre-pr` target in the project makefile. 
- [x] I am merging into the intended base branch.
- [x] This PR is small. 
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
