### PR TITLE
[BKY-6883] Update Rimble match

### DIFF
--- a/esports_data_from_rimble/README.md
+++ b/esports_data_from_rimble/README.md
@@ -176,9 +176,9 @@ to get the output:
   "Success": true,
   "Error": "",
   "Value": {
-    "MatchID": "2379357",
-    "Date": "2025-02-18",
-    "Winner": "MOUZ"
+    "MatchID": "2382907",
+    "Date": "2025-06-03",
+    "Winner": "EYEBALLERS"
   }
 }
 ```
@@ -317,12 +317,12 @@ to get the output:
   "Success": true,
   "Error": "",
   "Value": {
-    "MatchID": "2379357",
-    "Date": "2025-02-18",
+    "MatchID": "2382907",
+    "Date": "2025-06-03",
     "MapName": "Mirage",
-    "Team1": "MOUZ",
-    "Team2": "Virtus.pro",
-    "KillDiff": 34
+    "Team1": "Volt",
+    "Team2": "EYEBALLERS",
+    "KillDiff": 2
   }
 }
 ```

--- a/esports_data_from_rimble/match-winner.json.template
+++ b/esports_data_from_rimble/match-winner.json.template
@@ -2,8 +2,8 @@
   "code_file": "tmp/x.wasm",
   "function": "matchWinnerFromRimble",
   "input": {
-    "date": "2025-02-18",
-    "match_id": "2379357"
+    "date": "2025-06-03",
+    "match_id": "2382907"
   },
   "secret": {
     "api_key": "{{ .YOUR_RIMBLE_API_KEY }}"

--- a/esports_data_from_rimble/team-kill-diff.json.template
+++ b/esports_data_from_rimble/team-kill-diff.json.template
@@ -2,8 +2,8 @@
   "code_file": "tmp/x.wasm",
   "function": "teamKillDifferenceFromRimble",
   "input": {
-    "date": "2025-02-18",
-    "match_id": "2379357",
+    "date": "2025-06-03",
+    "match_id": "2382907",
     "map_name": "Mirage"
   },
   "secret": {

--- a/test/scripts/esports_data_from_rimble.txtar
+++ b/test/scripts/esports_data_from_rimble.txtar
@@ -21,9 +21,9 @@ cmp stdout expected-output-team-kill-diff.json
   "Success": true,
   "Error": "",
   "Value": {
-    "MatchID": "2379357",
-    "Date": "2025-02-18",
-    "Winner": "MOUZ"
+    "MatchID": "2382907",
+    "Date": "2025-06-03",
+    "Winner": "EYEBALLERS"
   }
 }
 -- expected-output-team-kill-diff.json --
@@ -31,11 +31,11 @@ cmp stdout expected-output-team-kill-diff.json
   "Success": true,
   "Error": "",
   "Value": {
-    "MatchID": "2379357",
-    "Date": "2025-02-18",
+    "MatchID": "2382907",
+    "Date": "2025-06-03",
     "MapName": "Mirage",
-    "Team1": "MOUZ",
-    "Team2": "Virtus.pro",
-    "KillDiff": 34
+    "Team1": "Volt",
+    "Team2": "EYEBALLERS",
+    "KillDiff": 2
   }
 }


### PR DESCRIPTION
## Describe your changes
Update the rimble match in the example to a more recent match. The `204 No Content` HTTP response for the previous match really looks like it is no longer being served(?), possibly aged out and should have really been a `404 Not Found` response. 

Might be worth getting in touch with rimble to find out if there is a max age of match data they serve or something like that. 

## Related Jira cards
https://blocky.atlassian.net/browse/BKY-6883

## Notes for reviewers
I am not 100% sure that the cause is because it aged out, but other match IDs and dates worked for me. 

@mwittie tagging you because I do not think this changes anything in the docs but I wanted to make sure. 

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] I have run `make pre-pr` and all checks have passed.
- [x] I am merging into the intended base branch.
- [x] This PR is small.
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
