### PR TITLE
[BKY-6883] Add Rimble example test back into rotation

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -58,28 +58,27 @@ func TestESportsDataFromPandaScore(t *testing.T) {
 		Run(filepath.Join(scriptDir, projectName+".txtar"))
 }
 
-// TODO: https://blocky.atlassian.net/browse/BKY-6883
-//func TestESportsDataFromRimble(t *testing.T) {
-//	projectName := "esports_data_from_rimble"
-//	projectDir := filepath.Join(examplesDir, projectName)
-//	requiredEnvVars := []string{
-//		"YOUR_RIMBLE_API_KEY",
-//	}
-//
-//	NewTestscriptTest(t, projectDir).
-//		ExecuteMakeTarget("build").
-//		CopyFile("tmp/x.wasm").
-//		CopyFile("config.toml").
-//		RenderTemplateFileFromEnvWithCleanup(
-//			"match-winner.json.template",
-//			requiredEnvVars,
-//		).
-//		RenderTemplateFileFromEnvWithCleanup(
-//			"team-kill-diff.json.template",
-//			requiredEnvVars,
-//		).
-//		Run(filepath.Join(scriptDir, projectName+".txtar"))
-//}
+func TestESportsDataFromRimble(t *testing.T) {
+	projectName := "esports_data_from_rimble"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"YOUR_RIMBLE_API_KEY",
+	}
+
+	NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		CopyFile("config.toml").
+		RenderTemplateFileFromEnvWithCleanup(
+			"match-winner.json.template",
+			requiredEnvVars,
+		).
+		RenderTemplateFileFromEnvWithCleanup(
+			"team-kill-diff.json.template",
+			requiredEnvVars,
+		).
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
 
 func TestHelloWorldAttestFnCall(t *testing.T) {
 	projectName := "hello_world_attest_fn_call"


### PR DESCRIPTION
## Describe your changes
In PR #55 Matteo fixed the rimble match info so that the tests once again pass. I accidently merged this PR, however, before he could pull in my updates from main. Since there weren't technically any conflicts, GH merged for him and left the Rimble example commented out. This PR uncomments the Rimble testscript test.

## Related Jira cards

## Notes for reviewers

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [ ] I have updated README files, if applicable.
- [ ] I have run `make pre-pr` and all checks have passed.
- [ ] I am merging into the intended base branch.
- [ ] This PR is small.
    - Otherwise, justify here:
- [ ] This PR does not require external communication
    - Otherwise, describe requirements here:
