### PR TITLE
[BKY-6790] on schedule test

### DIFF
--- a/.github/workflows/on-prs.yml
+++ b/.github/workflows/on-prs.yml
@@ -33,7 +33,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
           # Use the GH Actions role with limited permissions (i.e. read only access)
-          # defined here https://github.com/blocky/atlantis-aws/blob/main/aws_iam.tf
+          # defined here https://github.com/blocky/atlantis-aws/blob/main/aws_iam_role.tf
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/BkyOidcGithubActionsBlocky
           aws-region: us-west-2
 

--- a/.github/workflows/on-prs.yml
+++ b/.github/workflows/on-prs.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: hmarr/auto-approve-action@v3
 
   test-with-local-bky-server:
+    name: Test Attestation Service Examples Against Local BKY-AS Server
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for OIDC
@@ -48,6 +49,7 @@ jobs:
       - name: Run Tests
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          YOUR_COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
           YOUR_DHL_API_KEY: ${{ secrets.DHL_API_KEY }}
           YOUR_RIMBLE_API_KEY: ${{ secrets.RIMBLE_API_KEY }}
         run: |
@@ -59,9 +61,11 @@ jobs:
             --keep AWS_SESSION_TOKEN \
             --keep AWS_REGION \
             --keep GH_TOKEN \
-            --keep YOUR_RIMBLE_API_KEY \
+            --keep YOUR_COINGECKO_API_KEY \
             --keep YOUR_DHL_API_KEY \
+            --keep YOUR_RIMBLE_API_KEY \
             --run "\
+            go test -C test . -count=1 -v -run=TestCoinPricesFromCoingecko && \
             go test -C test . -count=1 -v -run=TestErrorHandlingAttestFnCall && \
             go test -C test . -count=1 -v -run=TestErrorHandlingOnChain && \
             go test -C test . -count=1 -v -run=TestESportsDataFromRimble && \

--- a/.github/workflows/on-prs.yml
+++ b/.github/workflows/on-prs.yml
@@ -1,6 +1,7 @@
 name: On Prs
 
 on:
+  workflow_dispatch:
   push:
     branches: [ 'main', 'release/*' ]
   pull_request:

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -1,0 +1,80 @@
+name: Scheduled Tests
+
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  test-with-live-bky-server:
+    name: Test Attestation Service Examples Against Live BKY-AS Server
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read  # Required to clone repo
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.1.0
+        with:
+          # Use the GH Actions role with limited permissions (i.e. read only access)
+          # defined here https://github.com/blocky/atlantis-aws/blob/main/aws_iam.tf
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/BkyOidcGithubActionsBlocky
+          aws-region: us-west-2
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: './test/go.mod'
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-24.11
+
+      - name: Fetch Server Enclave Measurement
+        run: |
+          response=$(curl \
+            --fail \
+            -H "Authorization: ${{ secrets.TYK_GITHUB_WORKFLOW_API_TOKEN }}" \
+            https://api.bky.sh/staging/delphi/unsafe/inspect
+          )
+
+          server_code_measure=$(echo "$response" | jq -r '.enclave_measurement.code')
+          server_platform=$(echo "$response" | jq -r '.enclave_measurement.platform')
+
+          if [ -z "$server_code_measure" ] || [ -z "$server_platform" ]; then
+            echo "Error: One or more response values are empty."
+            echo "Response: $response"
+            exit 1
+          fi
+
+          echo "SERVER_CODE_MEASURE=${server_code_measure}" >> "$GITHUB_ENV"
+          echo "SERVER_PLATFORM=${server_platform}" >> "$GITHUB_ENV"
+
+      - name: Run Tests
+        env:
+          LIVE_TEST_AUTH_TOKEN: ${{ secrets.TYK_GITHUB_WORKFLOW_API_TOKEN }}
+          LIVE_TEST_CODE: ${{ env.SERVER_CODE_MEASURE }}
+          LIVE_TEST_HOST: https://api.bky.sh/staging/delphi
+          LIVE_TEST_PLATFORM: ${{ env.SERVER_PLATFORM }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          YOUR_COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
+        run: |
+          nix-shell \
+            --pure \
+            --argstr bkyAsVersion "latest" \
+            --keep AWS_ACCESS_KEY_ID \
+            --keep AWS_SECRET_ACCESS_KEY \
+            --keep AWS_SESSION_TOKEN \
+            --keep AWS_REGION \
+            --keep LIVE_TEST_AUTH_TOKEN \
+            --keep LIVE_TEST_CODE \
+            --keep LIVE_TEST_HOST \
+            --keep LIVE_TEST_PLATFORM \
+            --keep GH_TOKEN \
+            --keep YOUR_COINGECKO_API_KEY \
+            --run "\
+            go test -C test ./live -count=1 -v -run=TestLiveCoinPricesFromCoingecko"

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -1,7 +1,6 @@
 name: Scheduled Tests
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 8 * * *'

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -19,7 +19,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
           # Use the GH Actions role with limited permissions (i.e. read only access)
-          # defined here https://github.com/blocky/atlantis-aws/blob/main/aws_iam.tf
+          # defined here https://github.com/blocky/atlantis-aws/blob/main/aws_iam_role.tf
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/BkyOidcGithubActionsBlocky
           aws-region: us-west-2
 

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -75,5 +75,4 @@ jobs:
             --keep LIVE_TEST_PLATFORM \
             --keep GH_TOKEN \
             --keep YOUR_COINGECKO_API_KEY \
-            --run "\
-            go test -C test ./live -count=1 -v -run=TestLiveCoinPricesFromCoingecko"
+            --run "make test-live"


### PR DESCRIPTION
## Describe your changes
This PR adds an `on-schedule.yml` that runs a nightly test of our attestation service examples against a live `bky-as` server (as opposed to the local version used in `on-prs`)

## Related Jira cards
[on schedule test](https://blocky.atlassian.net/browse/BKY-6790?atlOrigin=eyJpIjoiYzMzODk4ZTBlYzg4NGQ5NDg3MGFlMTgyNTA5ZDE0YjUiLCJwIjoiaiJ9)

## Notes for reviewers

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] I have run `make pre-pr` and all checks have passed.
- [x] I am merging into the intended base branch.
- [x] This PR is small.
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
