### PR TITLE
[BKY-6950] Update Rimble to use recent match id

### DIFF
--- a/esports_data_from_rimble/Makefile
+++ b/esports_data_from_rimble/Makefile
@@ -57,12 +57,6 @@ team-kill-diff: check build
 clean:
 	@rm -rf tmp
 
-.PHONY: update-rimble-test-data
-update-rimble-test-data:
-	@curl -s "https://rimbleanalytics.com/raw/csgo/match-status/?matchid=2382907&date=2025-06-03" \
-		-H "x-api-key: $(RIMBLE_API_KEY)" \
-		| jq . > rimble/testdata/match_data.json
-
 .PHONY: test-rimble
 test-rimble:
 	go test -v ./rimble/...

--- a/esports_data_from_rimble/match-winner.json.template
+++ b/esports_data_from_rimble/match-winner.json.template
@@ -1,10 +1,6 @@
 {
   "code_file": "tmp/x.wasm",
   "function": "matchWinnerFromRimble",
-  "input": {
-    "date": "2025-06-20",
-    "match_id": "2382613"
-  },
   "secret": {
     "api_key": "{{ .YOUR_RIMBLE_API_KEY }}"
   }

--- a/esports_data_from_rimble/rimble/rimble.go
+++ b/esports_data_from_rimble/rimble/rimble.go
@@ -50,6 +50,7 @@ type Metadata struct {
 
 type MatchData struct {
 	Metadata    Metadata `json:"metadata"`
+	Date        string   `json:"date"`
 	Team1Name   string   `json:"team_1_name"`
 	Team2Name   string   `json:"team_2_name"`
 	Teams       []Team   `json:"teams"`

--- a/esports_data_from_rimble/team-kill-diff.json.template
+++ b/esports_data_from_rimble/team-kill-diff.json.template
@@ -1,11 +1,6 @@
 {
   "code_file": "tmp/x.wasm",
   "function": "teamKillDifferenceFromRimble",
-  "input": {
-    "date": "2025-06-20",
-    "match_id": "2382613",
-    "map_name": "Inferno"
-  },
   "secret": {
     "api_key": "{{ .YOUR_RIMBLE_API_KEY }}"
   }

--- a/test/scripts/esports_data_from_rimble.txtar
+++ b/test/scripts/esports_data_from_rimble.txtar
@@ -5,7 +5,12 @@ cp stdout result-match-winner.json
 
 # [check] assert stdout contains correct match information
 exec jq -r '.transitive_attested_function_call.claims.output | @base64d | fromjson' result-match-winner.json
-cmp stdout expected-output-match-winner.json
+cp stdout output.json
+exec jq -e '.Success == true' output.json
+exec jq -e '.Error == ""' output.json
+exec jq -e '.Value.MatchID' output.json
+exec jq -e '.Value.Date' output.json
+exec jq -e '.Value.Winner' output.json
 
 # [execute] attest fn call to Rimble API for team kill information
 stdin team-kill-diff.json.template
@@ -14,28 +19,11 @@ cp stdout result-team-kill-diff.json
 
 # [check] assert stdout contains correct team kill information
 exec jq -r '.transitive_attested_function_call.claims.output | @base64d | fromjson' result-team-kill-diff.json
-cmp stdout expected-output-team-kill-diff.json
-
--- expected-output-match-winner.json --
-{
-  "Success": true,
-  "Error": "",
-  "Value": {
-    "MatchID": "2382613",
-    "Date": "2025-06-20",
-    "Winner": "paiN"
-  }
-}
--- expected-output-team-kill-diff.json --
-{
-  "Success": true,
-  "Error": "",
-  "Value": {
-    "MatchID": "2382613",
-    "Date": "2025-06-20",
-    "MapName": "Inferno",
-    "Team1": "paiN",
-    "Team2": "FURIA",
-    "KillDiff": 12
-  }
-}
+cp stdout output.json
+exec jq -e '.Success == true' output.json
+exec jq -e '.Error == ""' output.json
+exec jq -e '.Value.MatchID' output.json
+exec jq -e '.Value.Date' output.json
+exec jq -e '.Value.Team1' output.json
+exec jq -e '.Value.Team2' output.json
+exec jq -e '.Value.KillDiff' output.json


### PR DESCRIPTION
## Describe your changes
This PR updates the Rimble example so that it first queries for a list of recent matches. It then uses the first in match in the list to perform the "match winner" and "team kill diff" functions. The reason for this change is that match data is only available for two weeks on our current price tier, so we can't hardcode our examples/tests to use a specific match id.

## Related Jira cards
[rimble recent match id](https://blocky.atlassian.net/browse/BKY-6950?atlOrigin=eyJpIjoiYzgxMjNjNzI3YTgxNDUyOWI5YTBmMjM4ZDdmODFkN2UiLCJwIjoiaiJ9)

## Notes for reviewers

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] I have run `make pre-pr` and all checks have passed.
- [x] I am merging into the intended base branch.
- [x] This PR is small.
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
