### PR TITLE
[BKY-7036] Add missing live tests

### DIFF
--- a/.github/workflows/on-prs.yml
+++ b/.github/workflows/on-prs.yml
@@ -70,6 +70,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           YOUR_COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
           YOUR_DHL_API_KEY: ${{ secrets.DHL_API_KEY }}
+          YOUR_PANDASCORE_API_KEY: ${{ secrets.PANDASCORE_API_KEY }}
+          YOUR_PANDASCORE_API_ENDPOINT: ${{ secrets.PANDASCORE_API_ENDPOINT }}
           YOUR_RIMBLE_API_KEY: ${{ secrets.RIMBLE_API_KEY }}
           YOUR_RIMBLE_MATCH_DATE: ${{ env.RIMBLE_MATCH_DATE }}
           YOUR_RIMBLE_MATCH_ID: ${{ env.RIMBLE_MATCH_ID }}
@@ -84,6 +86,8 @@ jobs:
             --keep GH_TOKEN \
             --keep YOUR_COINGECKO_API_KEY \
             --keep YOUR_DHL_API_KEY \
+            --keep YOUR_PANDASCORE_API_KEY \
+            --keep YOUR_PANDASCORE_API_ENDPOINT \
             --keep YOUR_RIMBLE_API_KEY \
             --keep YOUR_RIMBLE_MATCH_DATE \
             --keep YOUR_RIMBLE_MATCH_ID \
@@ -91,6 +95,7 @@ jobs:
             go test -C test . -count=1 -v -run=TestCoinPricesFromCoingecko && \
             go test -C test . -count=1 -v -run=TestErrorHandlingAttestFnCall && \
             go test -C test . -count=1 -v -run=TestErrorHandlingOnChain && \
+            go test -C test . -count=1 -v -run=TestESportsDataFromPandaScore && \
             go test -C test . -count=1 -v -run=TestESportsDataFromRimble && \
             go test -C test . -count=1 -v -run=TestAttestFnCall && \
             go test -C test . -count=1 -v -run=TestHelloWorldOnChain && \

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -53,6 +53,24 @@ jobs:
           echo "SERVER_CODE_MEASURE=${server_code_measure}" >> "$GITHUB_ENV"
           echo "SERVER_PLATFORM=${server_platform}" >> "$GITHUB_ENV"
 
+      - name: Fetch Recent Match ID
+        run: |
+          response=$(curl --fail --location \
+              -H 'x-api-key: ${{ secrets.RIMBLE_API_KEY }}' \
+              'https://rimbleanalytics.com/raw/csgo/completed-matches/')
+          
+          match_date=$(echo "$response" | jq -r '.[0].date')
+          match_id=$(echo "$response" | jq -r '.[0].matchid')
+          
+          if [ -z "match_date" ] || [ -z "match_id" ]; then
+            echo "Error: One or more response values are empty."
+            echo "Response: $response"
+            exit 1
+          fi
+
+          echo "RIMBLE_MATCH_DATE=${match_date}" >> "$GITHUB_ENV"
+          echo "RIMBLE_MATCH_ID=${match_id}" >> "$GITHUB_ENV"
+
       - name: Run Tests
         env:
           LIVE_TEST_AUTH_TOKEN: ${{ secrets.TYK_GITHUB_WORKFLOW_API_TOKEN }}
@@ -61,6 +79,12 @@ jobs:
           LIVE_TEST_PLATFORM: ${{ env.SERVER_PLATFORM }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           YOUR_COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
+          YOUR_DHL_API_KEY: ${{ secrets.DHL_API_KEY }}
+          YOUR_PANDASCORE_API_KEY: ${{ secrets.PANDASCORE_API_KEY }}
+          YOUR_PANDASCORE_API_ENDPOINT: ${{ secrets.PANDASCORE_API_ENDPOINT }}
+          YOUR_RIMBLE_API_KEY: ${{ secrets.RIMBLE_API_KEY }}
+          YOUR_RIMBLE_MATCH_DATE: ${{ env.RIMBLE_MATCH_DATE }}
+          YOUR_RIMBLE_MATCH_ID: ${{ env.RIMBLE_MATCH_ID }}
         run: |
           nix-shell \
             --pure \
@@ -75,4 +99,10 @@ jobs:
             --keep LIVE_TEST_PLATFORM \
             --keep GH_TOKEN \
             --keep YOUR_COINGECKO_API_KEY \
+            --keep YOUR_DHL_API_KEY \
+            --keep YOUR_PANDASCORE_API_KEY \
+            --keep YOUR_PANDASCORE_API_ENDPOINT \
+            --keep YOUR_RIMBLE_API_KEY \
+            --keep YOUR_RIMBLE_MATCH_DATE \
+            --keep YOUR_RIMBLE_MATCH_ID \
             --run "make test-live"

--- a/test/live/live_test.go
+++ b/test/live/live_test.go
@@ -39,3 +39,187 @@ func TestLiveCoinPricesFromCoingecko(t *testing.T) {
 			requiredEnvVars).
 		Run(filepath.Join(scriptDir, projectName+".txtar"))
 }
+
+func TestLiveErrorHandlingAttestFnCall(t *testing.T) {
+	projectName := "error_handling_attest_fn_call"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		CopyFile("successFunc.json").
+		CopyFile("errorFunc.json").
+		CopyFile("panicFunc.json").
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
+
+func TestLiveESportsDataFromPandaScore(t *testing.T) {
+	projectName := "esports_data_from_pandascore"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+		"YOUR_PANDASCORE_API_ENDPOINT",
+		"YOUR_PANDASCORE_API_KEY",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		RenderTemplateFileFromEnvWithCleanup("fn-call.json", requiredEnvVars).
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
+
+func TestLiveESportsDataFromRimble(t *testing.T) {
+	projectName := "esports_data_from_rimble"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+		"YOUR_RIMBLE_MATCH_DATE",
+		"YOUR_RIMBLE_MATCH_ID",
+		"YOUR_RIMBLE_API_KEY",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		RenderTemplateFileFromEnvWithCleanup(
+			"match-winner.json.template",
+			requiredEnvVars,
+		).
+		RenderTemplateFileFromEnvWithCleanup(
+			"team-kill-diff.json.template",
+			requiredEnvVars,
+		).
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
+
+func TestLiveAttestFnCall(t *testing.T) {
+	projectName := "attest_fn_call"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("main.wasm").
+		CopyFile("main.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		CopyFile("fn-call.json").
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
+
+func TestLiveParamsAndSecrets(t *testing.T) {
+	projectName := "params_and_secrets"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		CopyFile("fn-call.json").
+		CopyFile("fn-call-error.json").
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
+
+func TestLiveRandom(t *testing.T) {
+	projectName := "random"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		CopyFile("fn-call.json").
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
+
+func TestLiveShipmentTrackingWithDHL(t *testing.T) {
+	projectName := "shipment_tracking_with_dhl"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+		"YOUR_DHL_API_KEY",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		RenderTemplateFileFromEnvWithCleanup("fn-call.json", requiredEnvVars).
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}
+
+func TestLiveTime(t *testing.T) {
+	projectName := "time"
+	projectDir := filepath.Join(examplesDir, projectName)
+	requiredEnvVars := []string{
+		"LIVE_TEST_PLATFORM",
+		"LIVE_TEST_CODE",
+		"LIVE_TEST_AUTH_TOKEN",
+		"LIVE_TEST_HOST",
+	}
+
+	test.NewTestscriptTest(t, projectDir).
+		ExecuteMakeTarget("build").
+		CopyFile("tmp/x.wasm").
+		RenderTemplateStringFromEnvWithCleanup(
+			liveTestConfigTemplate,
+			"config.toml",
+			requiredEnvVars).
+		CopyFile("fn-call.json").
+		Run(filepath.Join(scriptDir, projectName+".txtar"))
+}

--- a/test/scripts/error_handling_attest_fn_call.txtar
+++ b/test/scripts/error_handling_attest_fn_call.txtar
@@ -21,5 +21,4 @@ stdin panicFunc.json
 ! exec bky-as attest-fn-call
 
 # [check] assert stderr contains panic output
-stderr 'Expected panic call'
 stderr 'wasm error: unreachable'


### PR DESCRIPTION
## Describe your changes
Currently, our live test only runs the coin gecko example. This PR adds tests for the remaining examples. Though the on-chain examples are left out because they have no "live" version, as well as Sports Radar because if the API key renewal issues.

## Related Jira cards
[add missing live tests](https://blocky.atlassian.net/browse/BKY-7036)

## Notes for reviewers
I also created a Panda Score account under our engineering email and added the API key to this repository so we can now run Panda Score in the on-schedule and on-prs workflows.

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] I have run `make pre-pr` and all checks have passed.
- [x] I am merging into the intended base branch.
- [x] This PR is small.
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
